### PR TITLE
Don't access fogged_file

### DIFF
--- a/app/models/fogged/resource.rb
+++ b/app/models/fogged/resource.rb
@@ -89,16 +89,16 @@ module Fogged
     end
 
     def fogged_file
-      return @fogged_file if defined?(@fogged_file)
-
-      files = Fogged.resources.files
-      @fogged_file = files.get(fogged_name) || files.create(
-        :key => fogged_name,
-        :body => "",
-        :content_type => content_type
-      )
-      @fogged_file.public = "public_read"
-      @fogged_file.tap(&:save)
+      @_fogged_file ||= begin
+        files = Fogged.resources.files
+        file = files.get(fogged_name) || files.create(
+          :key => fogged_name,
+          :body => "",
+          :content_type => content_type
+        )
+        file.public = "public_read"
+        file.tap(&:save)
+      end
     end
 
     def find_size!

--- a/app/models/fogged/resources/aws_encoder.rb
+++ b/app/models/fogged/resources/aws_encoder.rb
@@ -41,7 +41,7 @@ module Fogged
         }
 
         if Fogged.zencoder_notification_url
-          params.merge!(:notifications => [Fogged.zencoder_notification_url])
+          params[:notifications] = [Fogged.zencoder_notification_url]
         end
 
         @resource.update!(
@@ -80,7 +80,7 @@ module Fogged
       end
 
       def bucket
-        @resource.fogged_file.directory.key
+        Fogged.resources.key
       end
 
       def fogged_name_for(type, number = 0)

--- a/app/models/fogged/resources/encoder.rb
+++ b/app/models/fogged/resources/encoder.rb
@@ -2,11 +2,11 @@ module Fogged
   module Resources
     class Encoder
       def self.for(resource)
-        "Fogged::Resources::#{provider_for(resource)}Encoder".constantize.new(resource)
+        "Fogged::Resources::#{provider}Encoder".constantize.new(resource)
       end
 
-      def self.provider_for(resource)
-        return :AWS if resource.fogged_file.class.to_s.include?("AWS")
+      def self.provider
+        return :AWS if Fogged.provider == :aws
       end
     end
   end


### PR DESCRIPTION
don't access `fogged_file` as it is painfully slow for big files
`files.get(name)` seems to be very slow for big files. I assume that the whole body of the S3 object is fetched.
The body is not always needed and this commit workarounds `fogged_file` to get the bucket name or the current provider.