### PR TITLE
fogged: address post-merge review comments

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -18,7 +18,7 @@ jobs:
       AWS_SECRET: XXX
       AWS_BUCKET: bucket
       AWS_REGION: eu-west-1
-      RUBYOPT: W0
+      RUBYOPT: -W0
     steps:
     - uses: actions/checkout@v4
     - name: Set up Ruby

--- a/app/controllers/fogged/resources_controller.rb
+++ b/app/controllers/fogged/resources_controller.rb
@@ -265,7 +265,7 @@ module Fogged
 
       case result
       when Array
-        result.slice(offset, count)
+        result.slice(offset, count) || []
       else
         result.limit(count).offset(offset)
       end

--- a/fogged.gemspec
+++ b/fogged.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = Gem::Requirement.new(">= 3.4", "< 4.1")
 
-  s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
+  s.files = Dir["{app,config,db,lib}/**/*", "CHANGELOG.md", "MIT-LICENSE", "Rakefile", "README.md"]
 
   s.add_dependency "fastimage", "~> 2.4"
   s.add_dependency "aws-sdk-s3", "~> 1.0"

--- a/lib/fogged.rb
+++ b/lib/fogged.rb
@@ -87,10 +87,10 @@ module Fogged
   def self.check_config
     case Fogged.provider
     when :aws
-      raise(ArgumentError, "AWS key is mandatory") unless Fogged.aws_key
-      raise(ArgumentError, "AWS secret is mandatory") unless Fogged.aws_secret
-      raise(ArgumentError, "AWS bucket is mandatory") unless Fogged.aws_bucket
-      raise(ArgumentError, "AWS region is mandatory") unless Fogged.aws_region
+      raise(ArgumentError, "AWS key is mandatory") if Fogged.aws_key.blank?
+      raise(ArgumentError, "AWS secret is mandatory") if Fogged.aws_secret.blank?
+      raise(ArgumentError, "AWS bucket is mandatory") if Fogged.aws_bucket.blank?
+      raise(ArgumentError, "AWS region is mandatory") if Fogged.aws_region.blank?
     else
       raise(ArgumentError, "Provider #{Fogged.provider} is not available!")
     end

--- a/test/dummy/test/controllers/resources_controller/index_test.rb
+++ b/test/dummy/test/controllers/resources_controller/index_test.rb
@@ -59,4 +59,15 @@ class ResourcesControllerIndexTest < ActionController::TestCase
 
     assert_json_resources([])
   end
+
+  test "should return an empty resources page when page is out of range" do
+    get :index,
+        params: {
+          type: "movie",
+          type_id: @movie.id,
+          page: 999
+        }
+
+    assert_json_resources([])
+  end
 end

--- a/test/fogged_test.rb
+++ b/test/fogged_test.rb
@@ -18,6 +18,37 @@ class FoggedTest < ActiveSupport::TestCase
     Fogged.aws_region = previous_region
   end
 
+  test "should reject blank AWS configuration values" do
+    {
+      "AWS key is mandatory" => [
+        -> { Fogged.aws_key },
+        ->(value) { Fogged.aws_key = value }
+      ],
+      "AWS secret is mandatory" => [
+        -> { Fogged.aws_secret },
+        ->(value) { Fogged.aws_secret = value }
+      ],
+      "AWS bucket is mandatory" => [
+        -> { Fogged.aws_bucket },
+        ->(value) { Fogged.aws_bucket = value }
+      ],
+      "AWS region is mandatory" => [
+        -> { Fogged.aws_region },
+        ->(value) { Fogged.aws_region = value }
+      ]
+    }.each do |message, (getter, setter)|
+      previous_value = getter.call
+      setter.call("")
+
+      error = assert_raise(ArgumentError) do
+        Fogged.configure
+      end
+      assert_equal message, error.message
+    ensure
+      setter.call(previous_value)
+    end
+  end
+
   test "should return directory public url" do
     assert_equal "https://test.s3.amazonaws.com/", Fogged.directory_public_url("test")
   end


### PR DESCRIPTION
### Summary

- Handles out-of-range resource pagination by returning an empty collection instead of `nil`.
- Treats blank AWS credentials, bucket, and region as missing configuration.
- Fixes release packaging and CI warning suppression details from the post-merge review.

### Why

PR #16 modernized `fogged` for 0.4.0, but several review comments landed after merge. This follow-up keeps the merged modernization intact while addressing the actionable compatibility and packaging issues reviewers raised.

### Review Notes

The historical migration comment was checked separately and left unchanged: current RuboCop reports no offense there, and restoring the old suppression would introduce a redundant-disable offense.
